### PR TITLE
Make scp task chainable\dependable

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,6 +54,7 @@ module.exports = function (options) {
                     gutil.log('gulp-scp:', gutil.colors.green(files.length, files.length === 1 ? 'file' : 'files', 'transferred successfully'));
                 }
                 cb();
+                if (options.cb) {options.cb()}
             });
         } else {
             gutil.log('gulp-scp:', gutil.colors.green('No files transferred'));


### PR DESCRIPTION
Added callback to options object to be able to chain tasks in gulp.taks via callback
See https://github.com/gulpjs/gulp/blob/master/docs/API.md#async-task-support

Since gulp-scp does not support streaming, returning stream (as per API doc) does not work.
gulp-scp could be refactored to support streams, or simply have callback(which I did).
